### PR TITLE
Add patch to exlcude tests folder from being installed into site-packages

### DIFF
--- a/recipe/exclude-tests-folder.patch
+++ b/recipe/exclude-tests-folder.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 01a3034c5..b8fcbc2ab 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -113,6 +113,8 @@ landlab = [
+ ]
+ [tool.setuptools.packages.find]
+ where = ["."]
++include = ["landlab*"]
++exclude = ["tests*"]
+ 
+ [tool.setuptools.dynamic]
+ readme = {file = ["README.rst", "AUTHORS.rst", "CHANGES.rst"]}

--- a/recipe/exclude-tests-folder.patch
+++ b/recipe/exclude-tests-folder.patch
@@ -1,12 +1,13 @@
-diff --git a/pyproject.toml b/pyproject.toml
-index 01a3034c5..b8fcbc2ab 100644
---- a/pyproject.toml
-+++ b/pyproject.toml
-@@ -113,6 +113,8 @@ landlab = [
- ]
- [tool.setuptools.packages.find]
- where = ["."]
-+include = ["landlab*"]
- 
- [tool.setuptools.dynamic]
- readme = {file = ["README.rst", "AUTHORS.rst", "CHANGES.rst"]}
+diff --git a/setup.py b/setup.py
+index 65a07493d..abb8f11e5 100644
+--- a/setup.py
++++ b/setup.py
+@@ -94,7 +94,7 @@ setup(
+         "model coupling",
+         "numerical modeling",
+     ],
+-    packages=find_packages(),
++    packages=find_packages(include=["landlab*"]),
+     package_data={
+         "": [
+             "tests/*txt",

--- a/recipe/exclude-tests-folder.patch
+++ b/recipe/exclude-tests-folder.patch
@@ -7,7 +7,6 @@ index 01a3034c5..b8fcbc2ab 100644
  [tool.setuptools.packages.find]
  where = ["."]
 +include = ["landlab*"]
-+exclude = ["tests*"]
  
  [tool.setuptools.dynamic]
  readme = {file = ["README.rst", "AUTHORS.rst", "CHANGES.rst"]}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - exclude-tests-folder.patch  # prevent tests folder from being installed
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: true  # [py2k]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://github.com/landlab/landlab/archive/v{{ version }}.tar.gz
   sha256: 9dade74cccb1670ba6e9d6d9f4878d3bacef7991a626e4f3f2fa3a5fcbc01042
+  patches:
+    - exclude-tests-folder.patch  # prevent tests folder from being installed
 
 build:
   number: 2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This pull request adds a patch to fix #48. I've modified *pyproject.toml* to only find packages that begin with `landlab*`.
